### PR TITLE
Drop Node v6 & v4 in favor of Node v10 & v12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
+  - '12'
+  - '10'
   - '8'
-  - '6'
-  - '4'


### PR DESCRIPTION
Per the Travis build results, these versions of Node appear unsupported